### PR TITLE
fix product-atom in OKHs

### DIFF
--- a/alpha/okh/okh-chair-helpful.yml
+++ b/alpha/okh/okh-chair-helpful.yml
@@ -1,11 +1,11 @@
 title: Chair 
-description: for some one to sit on 
-  procedures is described in “The Big Four: 
+# description: for some one to sit on 
+#   procedures is described in “The Big Four: 
 
-intended-output: Chair
-    identifier: Q15026
-    description: 	piece of furniture for sitting on
-    link: https://www.wikidata.org/wiki/Q15026
+# intended-output: Chair
+#     identifier: Q15026
+#     description: 	piece of furniture for sitting on
+#     link: https://www.wikidata.org/wiki/Q15026
 
 intended-use: 
 
@@ -67,7 +67,7 @@ tool-list-atoms:
 
 
 product-atom: 
-  - identifier: QH00002
+    identifier: QH00002
     descroption: chair
 
 bom-output-atoms:

--- a/alpha/okh/okh-manifest-surge-english-helpful.yml
+++ b/alpha/okh/okh-manifest-surge-english-helpful.yml
@@ -79,7 +79,7 @@ tool-list-atoms:
     link: https://www.wikidata.org/wiki/Q107196205
 
 product-atom: 
-  - identifier: QH00001
+    identifier: QH00001
     descroption: Fabric Mask
 
 bom-output-atoms:


### PR DESCRIPTION
This is a collection of atoms:

```yml
product-atom: 
  - identifier: QH00001
    descroption: Fabric Mask
```

but product atom should be singlular, so the YML should be

```yml
product-atom: 
    identifier: QH00001
    descroption: Fabric Mask
```

Also fix invalid yaml in okh-chair-helpful